### PR TITLE
Add missing inject decorator in InitializeStripeWebhookMiddleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,9 @@ import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 
 import StripeService from './stripe.js'
+import { inject } from '@adonisjs/core'
 
+@inject()
 export default class InitializeStripeWebhookMiddleware {
   constructor(protected stripe: StripeService) {}
 


### PR DESCRIPTION
This pull request adds the missing @inject decorator to the InitializeStripeWebhookMiddleware class, which fixes the dependency injection issue reported in issue #1.

Closes #1